### PR TITLE
Added a Dummy exception class for silencing IDE missing-return warnings on dummy callables

### DIFF
--- a/src/Dummy.php
+++ b/src/Dummy.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace DaveRandom\CallbackValidator;
+
+/**
+ * This exception can be used to silence IDEs complaining about missing return points.
+ */
+class Dummy extends \LogicException {}


### PR DESCRIPTION
This can be thrown from the body of a dummy callable used for signature validation to silence missing-return warnings, for example in PhpStorm. This is preferable to disabling missing-return warnings, since PhpStorm can be configured to ignore specific types of exception throws, which allows the exclusion to be more fine-tuned.

The name of this class is intentionally short to avoid ugly bloat of inline closures. Of course, it could be aliased, but this detracts from the convenience.

I found this technique useful in my projects, so perhaps it would be interesting to have it in the main repository.

A quick example:
```php
$signature = function(int $a, int $b) : C{ throw new Dummy; }; //IDE would complain about this without the dummy
if(!($sigType = CallbackType::createFromCallable($signature))->isSatisfiedBy($subject)){
	throw new \TypeError("Declaration of callable `" . CallbackType::createFromCallable($subject) . "` must be compatible with `" . $sigType . "`");
}
```